### PR TITLE
customise: allow internet sharing/WiFi hotspot (restrictions v1.0.3)

### DIFF
--- a/MACOS/IntuneManagement/SettingsCatalog/MacOS - OIB - Device Security - D - Restrictions - v1.0.3.json
+++ b/MACOS/IntuneManagement/SettingsCatalog/MacOS - OIB - Device Security - D - Restrictions - v1.0.3.json
@@ -9,7 +9,7 @@
     "description":  "",
     "lastModifiedDateTime@odata.type":  "#DateTimeOffset",
     "lastModifiedDateTime":  "2024-08-17T16:19:11.2338087Z",
-    "name":  "MacOS - OIB - Device Security - D - Restrictions - v1.0.2",
+    "name":  "MacOS - OIB - Device Security - D - Restrictions - v1.0.3",
     "platforms@odata.type":  "#microsoft.graph.deviceManagementConfigurationPlatforms",
     "platforms":  "macOS",
     "priorityMetaData":  null,
@@ -503,7 +503,7 @@
                                                                                                               "choiceSettingValue":  {
                                                                                                                                          "@odata.type":  "#microsoft.graph.deviceManagementConfigurationChoiceSettingValue",
                                                                                                                                          "settingValueTemplateReference":  null,
-                                                                                                                                         "value":  "com.apple.applicationaccess_allowinternetsharingmodification_false",
+                                                                                                                                         "value":  "com.apple.applicationaccess_allowinternetsharingmodification_true",
                                                                                                                                          "children@odata.type":  "#Collection(microsoft.graph.deviceManagementConfigurationSettingInstance)",
                                                                                                                                          "children":  [
 

--- a/MACOS/NativeImport/MacOS - OIB - Device Security - D - Restrictions - v1.0.3.json
+++ b/MACOS/NativeImport/MacOS - OIB - Device Security - D - Restrictions - v1.0.3.json
@@ -4,7 +4,7 @@
   "creationSource": null,
   "description": "",
   "lastModifiedDateTime": "2024-08-17T16:19:11.2338087Z",
-  "name": "MacOS - OIB - Device Security - D - Restrictions - v1.0.2",
+  "name": "MacOS - OIB - Device Security - D - Restrictions - v1.0.3",
   "platforms": "macOS",
   "priorityMetaData": null,
   "roleScopeTagIds": ["0"],
@@ -361,7 +361,7 @@
                 "settingInstanceTemplateReference": null,
                 "choiceSettingValue": {
                   "settingValueTemplateReference": null,
-                  "value": "com.apple.applicationaccess_allowinternetsharingmodification_false",
+                  "value": "com.apple.applicationaccess_allowinternetsharingmodification_true",
                   "children": []
                 }
               },


### PR DESCRIPTION
## Summary
- Enable `allowinternetsharingmodification` in the macOS restrictions policy (v1.0.2 → v1.0.3)
- Allows users to configure Internet Sharing (WiFi hotspot) from System Settings on managed macOS devices

## Test plan
- [ ] Verify deploy workflow triggers and creates v1.0.3 restrictions policy in Intune
- [ ] Confirm v1.0.2 is unassigned by auto-assign script
- [ ] Validate Internet Sharing can be toggled on a managed Mac