### PR TITLE
customise: allow trusted app sideloading (Microsoft Store v3.4.1)

### DIFF
--- a/WINDOWS/IntuneManagement/SettingsCatalog/Win - OIB - SC - Microsoft Store - D - Configuration - v3.4.1.json
+++ b/WINDOWS/IntuneManagement/SettingsCatalog/Win - OIB - SC - Microsoft Store - D - Configuration - v3.4.1.json
@@ -9,7 +9,7 @@
     "description":  "",
     "lastModifiedDateTime@odata.type":  "#DateTimeOffset",
     "lastModifiedDateTime":  "2024-12-05T20:12:53.1557469Z",
-    "name":  "Win - OIB - SC - Microsoft Store - D - Configuration - v3.4",
+    "name":  "Win - OIB - SC - Microsoft Store - D - Configuration - v3.4.1",
     "platforms@odata.type":  "#microsoft.graph.deviceManagementConfigurationPlatforms",
     "platforms":  "windows10",
     "priorityMetaData":  null,
@@ -48,7 +48,7 @@
                                                  "choiceSettingValue":  {
                                                                             "@odata.type":  "#microsoft.graph.deviceManagementConfigurationChoiceSettingValue",
                                                                             "settingValueTemplateReference":  null,
-                                                                            "value":  "device_vendor_msft_policy_config_applicationmanagement_allowalltrustedapps_0",
+                                                                            "value":  "device_vendor_msft_policy_config_applicationmanagement_allowalltrustedapps_1",
                                                                             "children@odata.type":  "#Collection(microsoft.graph.deviceManagementConfigurationSettingInstance)",
                                                                             "children":  [
 


### PR DESCRIPTION
## Summary
- Changes `AllowAllTrustedApps` from deny (`_0`) to allow (`_1`) in the Microsoft Store device configuration policy
- Version bump from v3.4 to v3.4.1

## Reason
OIB v3.4 explicitly denies sideloading of signed .appx/.msix packages. This breaks Adobe Creative Cloud Desktop, which uses trusted app packages to install components like Acrobat. Allowing trusted (signed) packages restores this functionality without enabling Developer Mode or unsigned apps.

## Test plan
- [ ] Deploy via `deploy-oib.yml` dry run
- [ ] Verify Adobe CC can install Acrobat on a test device after policy sync