### PR TITLE
customise: use %NtpServer% placeholder in Timezone policy

### DIFF
--- a/WINDOWS/IntuneManagement/SettingsCatalog/Win - OIB - SC - Device Security - D - Timezone - v3.4.json
+++ b/WINDOWS/IntuneManagement/SettingsCatalog/Win - OIB - SC - Device Security - D - Timezone - v3.4.json
@@ -78,7 +78,7 @@
               "simpleSettingValue": {
                 "@odata.type": "#microsoft.graph.deviceManagementConfigurationStringSettingValue",
                 "settingValueTemplateReference": null,
-                "value": "time.windows.com"
+                "value": "%NtpServer%"
               }
             },
             {


### PR DESCRIPTION
## Summary
- Rebases the NtpServer placeholder customisation onto upstream windows-v3.8 (OIBID-only delta upstream).
- Replaces literal `time.windows.com` with `%NtpServer%` for deploy.py substitution.
- File modified in place (no version bump — upstream didn't bump v3.4).

## Test plan
- [x] grep `%NtpServer%` returns 1 hit.
- [x] grep `time.windows.com` returns 0 hits.
- [x] OIBID preserved.