### PR TITLE
customise: allow user to revert to Legacy Outlook (Office Configuration v2.0.2)

### DIFF
--- a/MACOS/NativeImport/MacOS - OIB - SC - Microsoft Office - D - Office Configuration - v2.0.2.json
+++ b/MACOS/NativeImport/MacOS - OIB - SC - Microsoft Office - D - Office Configuration - v2.0.2.json
@@ -4,7 +4,7 @@
     "creationSource": null,
     "description": "",
     "lastModifiedDateTime": "2026-01-05T11:17:36.4013396Z",
-    "name": "MacOS - OIB - SC - Microsoft Office - D - Office Configuration - v2.0.1",
+    "name": "MacOS - OIB - SC - Microsoft Office - D - Office Configuration - v2.0.2",
     "platforms": "macOS",
     "priorityMetaData": null,
     "roleScopeTagIds": [
@@ -211,7 +211,7 @@
                 "auditRuleInformation": null,
                 "choiceSettingValue": {
                     "settingValueTemplateReference": null,
-                    "value": "com.apple.managedclient.preferences_enablenewoutlook_3",
+                    "value": "com.apple.managedclient.preferences_enablenewoutlook_2",
                     "children": []
                 }
             }


### PR DESCRIPTION
## Summary

- Drops `com.apple.managedclient.preferences_enablenewoutlook` from `3` (force New, no toggle) to `2` (New is default, but user can toggle back to Legacy via Help menu).
- Bumps `MacOS - OIB - SC - Microsoft Office - D - Office Configuration` from v2.0.1 → v2.0.2.

## Why

The upstream v2.0 value of `3` is currently locking a user out of Legacy Outlook on macOS even though Outlook 16.108+ still supports Legacy when policy permits (per Microsoft's Nov 2025 reversal of the Mac forced-migration). Microsoft's Legacy Outlook end-of-life is now Oct 2026, so setting `2` keeps New as the default for everyone while letting users with compatibility issues switch back for the remainder of the transition window.

## Test plan

- [ ] Merge triggers `trigger-deploy.yml` → `deploy-oib.yml` in `Thorp-Design/intune-policies`.
- [ ] `deploy.py` updates the existing policy (GUID `4f720edf-7758-444f-8189-26067342671b`) in place via PUT, renaming v2.0.1 → v2.0.2 and switching the EnableNewOutlook setting value.
- [ ] On the affected Mac after Intune sync, `/Library/Managed Preferences/com.microsoft.Outlook.plist` shows `EnableNewOutlook = 2` and the Help-menu toggle is available in Outlook.