### PR TITLE
customise: PSSO LoginFrequency 8h (Platform SSO v2.0.1)

### DIFF
--- a/MACOS/NativeImport/MacOS - OIB - SC - Authentication - D - Platform SSO - v2.0.1.json
+++ b/MACOS/NativeImport/MacOS - OIB - SC - Authentication - D - Platform SSO - v2.0.1.json
@@ -4,7 +4,7 @@
     "creationSource": null,
     "description": "",
     "lastModifiedDateTime": "2025-12-25T15:03:46.7709243Z",
-    "name": "MacOS - OIB - SC - Authentication - D - Platform SSO - v2.0",
+    "name": "MacOS - OIB - SC - Authentication - D - Platform SSO - v2.0.1",
     "platforms": "macOS",
     "priorityMetaData": null,
     "roleScopeTagIds": [
@@ -71,6 +71,17 @@
                                                     "settingValueTemplateReference": null,
                                                     "value": "com.apple.extensiblesso_platformsso_authenticationmethod_1",
                                                     "children": []
+                                                }
+                                            },
+                                            {
+                                                "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
+                                                "settingDefinitionId": "com.apple.extensiblesso_platformsso_loginfrequency",
+                                                "settingInstanceTemplateReference": null,
+                                                "auditRuleInformation": null,
+                                                "simpleSettingValue": {
+                                                    "@odata.type": "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue",
+                                                    "settingValueTemplateReference": null,
+                                                    "value": 28800
                                                 }
                                             },
                                             {


### PR DESCRIPTION
## Summary
- Adds `com.apple.extensiblesso_platformsso_loginfrequency = 28800` (8h) to the macOS Platform SSO policy.
- Bumps `MacOS - OIB - SC - Authentication - D - Platform SSO` → **v2.0.1**.
- NativeImport only — IntuneManagement copy left at v2.0 (not consumed by Thorp's `deploy.py`).

## Why
Forces a fresh PSSO ↔ Entra exchange every 8h, well inside the 10h Kerberos TGT lifetime. Mitigates a stuck-Cloud-TGT symptom where silent SE-key refreshes appear to fail near the TGT expiry boundary and users end up with no Kerberos ticket. The Apple/Intune default for this setting is 18h.

In a passwordless `UserSecureEnclaveKey` + `useSharedDeviceKeys=true` configuration (Thorp's setup), the SE key acts as a device-bound passkey, so the full PSSO exchange goes silently — no user-visible password prompt or Authenticator push expected at the 8h boundary.

## Test plan
- [ ] Deploy via Thorp `deploy-oib.yml` (in-place PATCH on existing policy id — preserves GUID, ProfileIdentifier and assignments)
- [ ] On a pilot Mac: confirm the setting lands in `profiles -P` / Settings > Profiles
- [ ] After 8h, confirm `app-sso platform -s` shows refreshed `tgt_cloud` (and `tgt_ad` if applicable) and no Authenticator push was triggered
- [ ] Monitor for unexpected re-auth prompts over 24-48h