### PR TITLE
customise: PSSO LoginFrequency 7d (Platform SSO v2.0.2)

### DIFF
--- a/MACOS/NativeImport/MacOS - OIB - SC - Authentication - D - Platform SSO - v2.0.2.json
+++ b/MACOS/NativeImport/MacOS - OIB - SC - Authentication - D - Platform SSO - v2.0.2.json
@@ -4,7 +4,7 @@
     "creationSource": null,
     "description": "",
     "lastModifiedDateTime": "2025-12-25T15:03:46.7709243Z",
-    "name": "MacOS - OIB - SC - Authentication - D - Platform SSO - v2.0.1",
+    "name": "MacOS - OIB - SC - Authentication - D - Platform SSO - v2.0.2",
     "platforms": "macOS",
     "priorityMetaData": null,
     "roleScopeTagIds": [
@@ -81,7 +81,7 @@
                                                 "simpleSettingValue": {
                                                     "@odata.type": "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue",
                                                     "settingValueTemplateReference": null,
-                                                    "value": 28800
+                                                    "value": 604800
                                                 }
                                             },
                                             {


### PR DESCRIPTION
Raises PSSO `loginfrequency` from **28800 (8h)** to **604800 (7d)**, superseding v2.0.1.

## Why
The 8h value forces a full PSSO IdP reauth ~daily. After an overnight sleep beyond the 8h window, passwordless (Secure Enclave) Macs land in `NeedsAuthentication` on a Touch ID unlock, leaving the on-prem Kerberos TGT (`tgt_ad`) unrefreshed and SMB/file-server access broken until a **password** unlock (observed on THORP-MBP-OG). A 7d window keeps the PSSO credential valid across overnight sleeps so the morning Kerberos TGT refresh proceeds silently.

## Safety
- Version-bump (v2.0.1 → v2.0.2) so `deploy.py` updates the existing policy **in place, preserving the GUID** — PSSO registration survives, no re-registration.
- Only the NativeImport copy is changed (the only format `deploy.py` reads), matching how the 8h change (v2.0 → v2.0.1) was done.
- No Conditional Access sign-in-frequency policy gates the native PSSO flow, so this isn't overridden.

https://claude.ai/code/session_016apWStRD8eoftpzva58RQU